### PR TITLE
Remove all complete items from progress history and timeout checklist

### DIFF
--- a/gate-executor.js
+++ b/gate-executor.js
@@ -113,17 +113,16 @@ function GateExecutor(options, instance_counter) {
             work.end = Date.now();
             // Remove the work item from the work-in-progress set.  As
             // work items may complete out of order, prune the history
-            // from the front until the first incomplete work
-            // item. Later complete work items will eventually be
-            // reached on another processing round.
+            // of all work items that are complete.Later complete work items
+			// will eventually be reached on another processing round.
             work.done = true;
             delete progress.lookup[work.id];
-            while (progress.history[0] && progress.history[0].done) {
-                progress.history.shift();
-            }
-            while (timeout_checklist[0] && timeout_checklist[0].done) {
-                timeout_checklist.shift();
-            }
+			progress.history = progress.history.filter((workItem) => {
+				return !workItem.done
+			});
+			timeout_checklist = timeout_checklist.filter((workItem) => {
+				return !workItem.done
+			});
             // If the work item was a gate, it is now complete, and the
             // instance can be ungated, allowing later work items in the
             // queue to be processed.


### PR DESCRIPTION
Fixes https://github.com/senecajs/gate-executor/issues/27 

When a work item is complete, instead of starting at the beginning of `progress.history` / `timeout_checklist`, simply set them to list of incomplete items only. This ensures that if the first element of these arrays is a hanging work item, the lists do not grow until a timeout happens.